### PR TITLE
Add os product tag based on /etc/os-release

### DIFF
--- a/src/subscription_manager/model/__init__.py
+++ b/src/subscription_manager/model/__init__.py
@@ -15,6 +15,7 @@
 import logging
 
 from rhsm.certificate2 import CONTENT_ACCESS_CERT_TYPE
+from rhsmlib.facts.hwprobe import HardwareCollector
 
 log = logging.getLogger(__name__)
 
@@ -89,10 +90,12 @@ class EntitlementSource:
         return self._entitlements[key]
 
 
-def find_content(ent_source, content_type=None):
+def find_content(ent_source, content_type=None, use_os_release_product=False):
     """
     Scan all entitlements looking for content of the given type. (string)
     Type will be compared case insensitive.
+    If use_os_release_product is enabled, generate a os-product-version tag and
+    add it ot the list of product_tags
 
     Returns a list of model.Content.
     """
@@ -101,10 +104,15 @@ def find_content(ent_source, content_type=None):
     content_labels = set()
     log.debug("Searching for content of type: %s" % content_type)
     for entitlement in ent_source:
+        if use_os_release_product:
+            all_product_tags = add_os_product_tags(ent_source.product_tags)
+        else:
+            all_product_tags = ent_source.product_tags
+
         for content in entitlement.contents:
             # this is basically matching_content from repolib
             if content.content_type.lower() == content_type.lower() and content_tag_match(
-                content.tags, ent_source.product_tags
+                content.tags, all_product_tags
             ):
                 if entitlement.entitlement_type == CONTENT_ACCESS_CERT_TYPE:
                     content_access_entitlement_content[content.label] = content
@@ -117,6 +125,19 @@ def find_content(ent_source, content_type=None):
         if label not in content_labels:
             entitled_content.append(content)
     return entitled_content
+
+
+def add_os_product_tags(product_tags):
+    """Add [os-id]-[os-version] tag to product tag list based on /etc/os-release
+
+    Returns the product_tags including the os-product tag
+    """
+    all_tags = product_tags
+
+    dist_info = HardwareCollector().get_distribution()
+    os_product = "{name}-{version}".format(name=dist_info[4], version=dist_info[1])
+    all_tags.append(os_product)
+    return all_tags
 
 
 def content_tag_match(content_tags, product_tags):

--- a/src/subscription_manager/model/__init__.py
+++ b/src/subscription_manager/model/__init__.py
@@ -136,7 +136,14 @@ def add_os_product_tags(product_tags):
 
     dist_info = HardwareCollector().get_distribution()
     os_product = "{name}-{version}".format(name=dist_info[4], version=dist_info[1])
-    all_tags.append(os_product)
+
+    if isinstance(all_tags, list):
+        all_tags.append(os_product)
+    elif isinstance(all_tags, set):
+        all_tags.add(os_product)
+    else:
+        raise TypeError("Unsupported collection type for `all_tags`. Use a list or set.")
+
     return all_tags
 
 

--- a/src/subscription_manager/repolib.py
+++ b/src/subscription_manager/repolib.py
@@ -516,13 +516,31 @@ class RepoUpdateActionCommand:
         # assumes items in content_list are hashable
         return set(content_list)
 
+    def use_os_release_product_enabled(self):
+        try:
+            use_os_release_product = conf["rhsm"].get_int("use_os_release_product")
+        except ValueError as e:
+            log.exception(e)
+            return False
+        except configparser.Error as e:
+            log.exception(e)
+            return False
+        else:
+            if use_os_release_product is None:
+                return False
+        return bool(use_os_release_product)
+
     # Expose as public API for RepoActionInvoker.is_managed, since that
     # is used by Openshift tooling.
     # See https://bugzilla.redhat.com/show_bug.cgi?id=1223038
     def matching_content(self) -> List["Content"]:
         content = []
         for content_type in ALLOWED_CONTENT_TYPES:
-            content += model.find_content(self.ent_source, content_type=content_type)
+            content += model.find_content(
+                self.ent_source,
+                content_type=content_type,
+                use_os_release_product=self.use_os_release_product_enabled(),
+            )
         return content
 
     def get_all_content(self, baseurl: str, ca_cert: str) -> List[Repo]:

--- a/test/test_repolib.py
+++ b/test/test_repolib.py
@@ -289,6 +289,17 @@ class RepoActionReportTests(fixture.SubManFixture):
                 self.fail("Expected to match the report label regex  %s but did not" % report_label_regex)
 
 
+USE_OS_RELEASE_PRODUCT_DISABLED = """
+[rhsm]
+use_os_release_product = 0
+"""
+
+USE_OS_RELEASE_PRODUCT_ENABLED = """
+[rhsm]
+use_os_release_product = 1
+"""
+
+
 class RepoUpdateActionTests(fixture.SubManFixture):
     def setUp(self):
         super(RepoUpdateActionTests, self).setUp()
@@ -462,6 +473,18 @@ class RepoUpdateActionTests(fixture.SubManFixture):
         self.assertEqual("some path", c4["ui_repoid_vars"])
         c2 = self._find_content(content, "c2")
         self.assertEqual(None, c2["ui_repoid_vars"])
+
+    @patch.object(repolib, "conf", ConfigFromString(config_string=USE_OS_RELEASE_PRODUCT_DISABLED))
+    def test_use_os_release_product_is_disabled(self):
+        update_action = RepoUpdateActionCommand()
+        enabled = update_action.use_os_release_product_enabled()
+        self.assertFalse(enabled)
+
+    @patch.object(repolib, "conf", ConfigFromString(config_string=USE_OS_RELEASE_PRODUCT_ENABLED))
+    def test_use_os_release_product_is_enabled(self):
+        update_action = RepoUpdateActionCommand()
+        enabled = update_action.use_os_release_product_enabled()
+        self.assertTrue(enabled)
 
     def test_tags_found(self):
         update_action = RepoUpdateActionCommand()


### PR DESCRIPTION
Currently, content filter based on the product-tags only works for RHEL. The content filter method should also be usable for other OSses, like CentOS, SuSE or even Debian/Ubuntu. With this approach, a [os-name]-[os-version] tag is created based on /etc/os-release. The tag is only generated and added if the feature is activated by setting use_os_release_product=1 in /etc/rhsm/rhsm.conf