### PR TITLE
All debian/ubuntu systems supports arch 'all' pkgs

### DIFF
--- a/src/rhsmlib/facts/pkg_arches.py
+++ b/src/rhsmlib/facts/pkg_arches.py
@@ -60,6 +60,9 @@ class SupportedArchesCollector(collector.FactsCollector):
         except Exception as e:
             log.error("Error getting dpkg foreign architecture: %s", e)
 
+        # All debian systems supports no-architecture packages (= 'all'), too
+        arches.append("all")
+
         return {"supported_architectures": ",".join(arches)}
 
     def get_all(self) -> Dict[str, str]:

--- a/test/rhsmlib/facts/test_pkg_arches.py
+++ b/test/rhsmlib/facts/test_pkg_arches.py
@@ -24,28 +24,28 @@ class TestSupportedArchesCollector(unittest.TestCase):
         collector = pkg_arches.SupportedArchesCollector(collected_hw_info={"distribution.name": "Debian"})
         MockCheckOutput.side_effect = self.helper_dpkg_no_foreign
         fact = collector.get_all()
-        self.assertEqual(fact["supported_architectures"], "amd64")
+        self.assertEqual(fact["supported_architectures"], "amd64,all")
 
     @patch("subprocess.check_output")
     def test_single_arch_on_ubuntu(self, MockCheckOutput):
         collector = pkg_arches.SupportedArchesCollector(collected_hw_info={"distribution.name": "Ubuntu"})
         MockCheckOutput.side_effect = self.helper_dpkg_no_foreign
         fact = collector.get_all()
-        self.assertEqual(fact["supported_architectures"], "amd64")
+        self.assertEqual(fact["supported_architectures"], "amd64,all")
 
     @patch("subprocess.check_output")
     def test_multi_arch_on_ubuntu(self, MockCheckOutput):
         collector = pkg_arches.SupportedArchesCollector(collected_hw_info={"distribution.name": "Debian"})
         MockCheckOutput.side_effect = self.helper_dpkg_foreign
         fact = collector.get_all()
-        self.assertEqual(fact["supported_architectures"], "amd64,i386")
+        self.assertEqual(fact["supported_architectures"], "amd64,i386,all")
 
     @patch("subprocess.check_output")
     def test_multi_arch_on_debian(self, MockCheckOutput):
         collector = pkg_arches.SupportedArchesCollector(collected_hw_info={"distribution.name": "Ubuntu"})
         MockCheckOutput.side_effect = self.helper_dpkg_foreign
         fact = collector.get_all()
-        self.assertEqual(fact["supported_architectures"], "amd64,i386")
+        self.assertEqual(fact["supported_architectures"], "amd64,i386,all")
 
     @patch("subprocess.check_output")
     def test_none_arch_on_redhat(self, MockCheckOutput):


### PR DESCRIPTION
Arch 'all' is noarch in debian/ubuntu. In case users want to do limit for repository only supported arch 'all', this information need to be send to candlepin as fact.